### PR TITLE
Use a single thread and avoid allocations

### DIFF
--- a/rust-hyper/src/main.rs
+++ b/rust-hyper/src/main.rs
@@ -1,11 +1,24 @@
-use hyper::client::Client;
+use hyper::{body::Buf, client::Client};
+use std::io::{stdout, Write};
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
     let uri = "http://127.0.0.1:8000/get".parse()?;
     let response = client.get(uri).await?;
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
-    println!("{}", String::from_utf8(body_bytes.to_vec())?);
+    let mut body = hyper::body::aggregate(response.into_body()).await?;
+
+    let mut stdout = stdout().lock();
+    loop {
+        let chunk = body.chunk();
+        if chunk.is_empty() {
+            break;
+        }
+
+        let n_read = stdout.write(chunk)?;
+        body.advance(n_read);
+    }
+    stdout.flush()?;
+
     Ok(())
 }


### PR DESCRIPTION
Your Zig client is not multithreaded, therefore, a better comparison would be to use the single threaded runtime of Tokio.

I got a speedup of 2x.

Your Zig client is not even async, right? This is also an unfair comparison then.