### PR TITLE
Add modified whisker plotter

### DIFF
--- a/plot_whisker.py
+++ b/plot_whisker.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+"""This program shows `hyperfine` benchmark results as a box and whisker plot.
+
+Quoting from the matplotlib documentation:
+    The box extends from the lower to upper quartile values of the data, with
+    a line at the median. The whiskers extend from the box to show the range
+    of the data. Flier points are those past the end of the whiskers.
+"""
+
+import argparse
+import json
+import matplotlib.pyplot as plt
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("file", help="JSON file with benchmark results")
+parser.add_argument("--title", help="Plot Title")
+parser.add_argument(
+    "--labels", help="Comma-separated list of entries for the plot legend"
+)
+parser.add_argument(
+    "-o", "--output", help="Save image to the given filename."
+)
+
+args = parser.parse_args()
+
+with open(args.file) as f:
+    results = json.load(f)["results"]
+
+if args.labels:
+    labels = args.labels.split(",")
+else:
+    labels = [b["command"] for b in results]
+times = [b["times"] for b in results]
+
+fig, ax = plt.subplots()
+boxplot = ax.boxplot(times, vert=True, patch_artist=True)
+cmap = plt.get_cmap("rainbow")
+colors = [cmap(val / len(times)) for val in range(len(times))]
+
+for patch, color in zip(boxplot["boxes"], colors):
+    patch.set_facecolor(color)
+
+if args.title:
+    plt.title(args.title)
+
+ax.set_xticklabels(labels)
+plt.xticks(rotation=70)
+plt.legend(handles=boxplot["boxes"], labels=labels, loc="best", fontsize="medium")
+plt.ylabel("Time [s]")
+plt.ylim(0, None)
+plt.tight_layout()
+plt.grid()
+if args.output:
+    plt.savefig(args.output)
+else:
+    plt.show()


### PR DESCRIPTION
Related to #13 
Uses the x-axis tick labels to name the columns - colors no longer depended upon for identification of the boxes.
Also adds a grid for convenience.

![Figure_1](https://github.com/orhun/zig-http-benchmarks/assets/80536083/0440e6e9-d982-49f8-8b64-9144ca7cf513)
